### PR TITLE
fix: generate dynamic dummy dockerfile content

### DIFF
--- a/src/patch-module.ts
+++ b/src/patch-module.ts
@@ -23,7 +23,7 @@ export function patchModule(module: string, expectedVersion: string) {
   const dockerfile = join(layerdir, 'Dockerfile');
   if (!existsSync(layerdir)) {
     mkdirSync(layerdir);
-    writeFileSync(dockerfile, '# dummy');
+    writeFileSync(dockerfile, `# dummy${module}`);
     console.error(LOG_PREFIX + `created ${dockerfile}`);
   } else {
     console.error(LOG_PREFIX + `skipped ${dockerfile}`);

--- a/test/hello.test.ts
+++ b/test/hello.test.ts
@@ -46,7 +46,7 @@ describe('patchModule()', () => {
     patchModule(module, EXPECTED_VERSION);
     const dockerfile = tryFindDummyDockerfile(module);
     expect(dockerfile).toBeDefined();
-    expect(readFileSync(dockerfile!, 'utf8')).toStrictEqual('# dummy');
+    expect(readFileSync(dockerfile!, 'utf8')).toStrictEqual(`# dummy${module}`);
   });
 
   test('does not fail if the module is not in the closure', () => {


### PR DESCRIPTION
Generate different dummy content for the Dockerfile to avoid publishing the same zip asset.

Fixes #2 